### PR TITLE
Refactor babel in deps and unify npm build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "My react seed project",
   "scripts": {
     "start": "node ./server",
-    "build": "npm run build-client && npm run build-server",
-    "build-client": "webpack --config ./tools/webpack.prod",
+    "build": "webpack --config ./tools/webpack.prod",
     "test": "rimraf lib && NODE_ENV=test ./node_modules/mocha/bin/mocha --compilers js:babel-core/register --recursive",
     "test:watch": "npm test -- --watch",
     "coverage": "nyc npm test",
@@ -17,8 +16,6 @@
   "dependencies": {
     "assets-webpack-plugin": "^3.4.0",
     "autoprefixer": "^6.3.6",
-    "babel-cli": "6.9.0",
-    "babel-core": "6.9.1",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
@@ -49,9 +46,9 @@
     "webpack": "1.13.1"
   },
   "devDependencies": {
+    "babel-core": "^6.10.4",
     "babel-eslint": "^6.0.4",
     "babel-plugin-__coverage__": "^11.0.0",
-    "babel-register": "^6.9.0",
     "expect": "^1.20.1",
     "mocha": "^2.5.3",
     "nyc": "^6.4.4",


### PR DESCRIPTION
Now that we are no longer using babel to transpire server-side code, we
can remove `babel-cli` and `babel-register`. We can also move
`babel-core` down to devDependencies because it is only needed for test
running (mocha).
